### PR TITLE
Fix centaur OnRefresh incorrect reference

### DIFF
--- a/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/centaur_warrunner_stampede_lua.txt
+++ b/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/centaur_warrunner_stampede_lua.txt
@@ -26,6 +26,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityType"					"DOTA_ABILITY_TYPE_ULTIMATE"
 		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
 		"SpellDispellableType"			"SPELL_DISPELLABLE_NO"
 		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
 

--- a/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/modifier_centaur_warrunner_stampede_lua.lua
+++ b/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/modifier_centaur_warrunner_stampede_lua.lua
@@ -33,7 +33,7 @@ function modifier_centaur_warrunner_stampede_lua:OnCreated( kv )
 			-- victim = target,
 			attacker = self:GetParent(),
 			damage = base_damage + self:GetParent():GetStrength()*strength_pct,
-			damage_type = DAMAGE_TYPE_MAGICAL,
+			damage_type = self:GetAbility():GetAbilityDamageType(),
 			ability = self:GetAbility(), --Optional.
 		}
 
@@ -49,8 +49,8 @@ function modifier_centaur_warrunner_stampede_lua:OnRefresh( kv )
 	-- references
 	self.radius = self:GetAbility():GetSpecialValueFor( "radius" ) -- special value
 	self.slow_duration = self:GetAbility():GetSpecialValueFor( "slow_duration" ) -- special value
-	local base_damage = self:GetAbility():GetSpecialValueFor( "radius" ) -- special value
-	local strength_pct = self:GetAbility():GetSpecialValueFor( "radius" ) -- special value
+	local base_damage = self:GetAbility():GetSpecialValueFor( "base_damage" ) -- special value
+	local strength_pct = self:GetAbility():GetSpecialValueFor( "strength_damage" ) -- special value
 
 	-- Start interval
 	if IsServer() then
@@ -59,7 +59,7 @@ function modifier_centaur_warrunner_stampede_lua:OnRefresh( kv )
 			-- victim = target,
 			attacker = self:GetParent(),
 			damage = base_damage + self:GetParent():GetStrength()*strength_pct,
-			damage_type = DAMAGE_TYPE_MAGICAL,
+			damage_type = self:GetAbility():GetAbilityDamageType(),
 			ability = self:GetAbility(), --Optional.
 		}
 

--- a/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/modifier_centaur_warrunner_stampede_lua.lua
+++ b/scripts/vscripts/lua_abilities/centaur_warrunner_stampede_lua/modifier_centaur_warrunner_stampede_lua.lua
@@ -32,7 +32,7 @@ function modifier_centaur_warrunner_stampede_lua:OnCreated( kv )
 		self.damageTable = {
 			-- victim = target,
 			attacker = self:GetParent(),
-			damage = base_damage + self:GetParent():GetStrength()*strength_pct,
+			damage = base_damage + self:GetCaster():GetStrength()*strength_pct,
 			damage_type = self:GetAbility():GetAbilityDamageType(),
 			ability = self:GetAbility(), --Optional.
 		}
@@ -58,7 +58,7 @@ function modifier_centaur_warrunner_stampede_lua:OnRefresh( kv )
 		self.damageTable = {
 			-- victim = target,
 			attacker = self:GetParent(),
-			damage = base_damage + self:GetParent():GetStrength()*strength_pct,
+			damage = base_damage + self:GetCaster():GetStrength()*strength_pct,
 			damage_type = self:GetAbility():GetAbilityDamageType(),
 			ability = self:GetAbility(), --Optional.
 		}


### PR DESCRIPTION
This patch will do the following:

- Fix an incorrect reference for OnRefresh centaur stampede
- Change damage table to use self:GetAbility():GetAbilityDamageType()
- Add `"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"` to the txt file
- Fix Centaur stampede to use Strength of caster (as according to DotA and also since buffed creeps don't have strength)